### PR TITLE
restart firewalld to apply firewall changes

### DIFF
--- a/doc/vagrant-dev-env.rst
+++ b/doc/vagrant-dev-env.rst
@@ -69,6 +69,7 @@ than VirtualBox shared folders. On Fedora 22::
     firewall-cmd --permanent --add-port=2049/tcp
     firewall-cmd --permanent --add-port=111/udp
     firewall-cmd --permanent --add-port=111/tcp
+    sudo systemctl restart firewalld
 
 Find a location in the system's home directory and checkout the Kolla repo::
 


### PR DESCRIPTION
Either restart firewalld, or issue these same four add-port commands again w/o the `--permanent` to apply the changes. Not sure if this is the right way to send a doc fix, apologies if not.