### PR TITLE
Fix wrong behavior when the source is a directory

### DIFF
--- a/docker/base/set_configs.py
+++ b/docker/base/set_configs.py
@@ -158,7 +158,7 @@ def copy_files(data):
             LOG.info("Copying %s to %s",
                      os.path.join(source_path, src), dest_path)
 
-            if os.path.isdir(src):
+            if os.path.isdir(os.path.join(source_path, src)):
                 shutil.copytree(os.path.join(source_path, src), dest_path)
             else:
                 shutil.copy(os.path.join(source_path, src), dest_path)


### PR DESCRIPTION
When we set directories in "config_files" section of config.json, the script fails because it don't check the right path.