### PR TITLE
fix hard-coded keystone user name for nova

### DIFF
--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -135,7 +135,7 @@ auth_type = password
 project_domain_id = default
 user_domain_id = default
 project_name = service
-username = nova
+username = {{ nova_keystone_user }}
 password = {{ nova_keystone_password }}
 
 [libvirt]


### PR DESCRIPTION
found there's a var for nova keystone user in defaults, should use it.