### PR TITLE
Fix incorrect image variable name

### DIFF
--- a/ansible/roles/mistral/tasks/pull.yml
+++ b/ansible/roles/mistral/tasks/pull.yml
@@ -17,5 +17,5 @@
   kolla_docker:
     action: "pull_image"
     common_options: "{{ docker_common_options }}"
-    image: "{{ mistral_executorngine_image_full }}"
+    image: "{{ mistral_executor_image_full }}"
   when: inventory_hostname in groups['mistral-executor']


### PR DESCRIPTION
kolla-ansible pull was failing because incorrect image variable name
"mistral_executorngine_image_full"

Should be "mistral_executor_image_full"