### PR TITLE
add subpath feature when access openstack dashboard

### DIFF
--- a/ansible/roles/horizon/templates/horizon.conf.j2
+++ b/ansible/roles/horizon/templates/horizon.conf.j2
@@ -1,4 +1,5 @@
 {% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set webroot = 'dashboard' %}
 Listen {{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['address'] }}:80
 
 <VirtualHost *:80>
@@ -9,15 +10,15 @@ Listen {{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['addr
     WSGIScriptReloading On
     WSGIDaemonProcess horizon-http processes=5 threads=1 user=horizon group=horizon display-name=%{GROUP} python-path={{ python_path }}
     WSGIProcessGroup horizon-http
-    WSGIScriptAlias / {{ python_path }}/openstack_dashboard/wsgi/django.wsgi
+    WSGIScriptAlias /{{ webroot }} {{ python_path }}/openstack_dashboard/wsgi/django.wsgi
     WSGIPassAuthorization On
 
-    <Location "/">
+    <Location "/{{ webroot }}">
         Require all granted
     </Location>
 
-    Alias /static {{ python_path }}/static
-    <Location "/static">
+    Alias /{{ webroot }}/static {{ python_path }}/static
+    <Location "/{{ webroot }}/static">
         SetHandler None
     </Location>
 </Virtualhost>

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -11,7 +11,7 @@ COMPRESS_OFFLINE = True
 
 # WEBROOT is the location relative to Webserver root
 # should end with a slash.
-WEBROOT = '/'
+WEBROOT = '/dashboard'
 # LOGIN_URL = WEBROOT + 'auth/login/'
 # LOGOUT_URL = WEBROOT + 'auth/logout/'
 #


### PR DESCRIPTION
In our project,we need access horizon through subpath,
for example,http://localhost/dashboard/dashboard/auth/login/
Our project manager find this feature is useful.
So tell us contribute to community