### PR TITLE
Add dashboard_webroot config when access dashboard page

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -264,3 +264,12 @@ ceph_cache_rule: "cache host firstn"
 #######################################
 manila_enable_dhss: "yes"
 manila_dhss: "{{ 'True' if manila_enable_dhss | bool else 'False' }}"
+
+
+########################################################################
+# dashboard_webroot - Access openstack dashboard by dashboard_webroot
+# When you modify the dashboard_webroot config in /etc/kolla/globals.yml
+# Then you can visit the openstack dashboard by dashboard_webroot config
+# For example : http://localhost/dashboard/auth/login
+########################################################################
+dashboard_webroot: ""

--- a/ansible/roles/horizon/templates/horizon.conf.j2
+++ b/ansible/roles/horizon/templates/horizon.conf.j2
@@ -9,15 +9,15 @@ Listen {{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['addr
     WSGIScriptReloading On
     WSGIDaemonProcess horizon-http processes=5 threads=1 user=horizon group=horizon display-name=%{GROUP} python-path={{ python_path }}
     WSGIProcessGroup horizon-http
-    WSGIScriptAlias / {{ python_path }}/openstack_dashboard/wsgi/django.wsgi
+    WSGIScriptAlias /{{ dashboard_webroot }} {{ python_path }}/openstack_dashboard/wsgi/django.wsgi
     WSGIPassAuthorization On
 
-    <Location "/">
+    <Location "/{{ dashboard_webroot }}">
         Require all granted
     </Location>
 
-    Alias /static {{ python_path }}/static
-    <Location "/static">
+    Alias /{{ dashboard_webroot }}/static {{ python_path }}/static
+    <Location "/{{ dashboard_webroot }}/static">
         SetHandler None
     </Location>
 </Virtualhost>

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -11,7 +11,7 @@ COMPRESS_OFFLINE = True
 
 # WEBROOT is the location relative to Webserver root
 # should end with a slash.
-WEBROOT = '/'
+WEBROOT = '/{{ dashboard_webroot }}'
 # LOGIN_URL = WEBROOT + 'auth/login/'
 # LOGOUT_URL = WEBROOT + 'auth/logout/'
 #

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -157,3 +157,9 @@ neutron_external_interface: "eth1"
 # selected then swift_devices_name should specify a pattern which would match to
 # filesystems' labels prepared for swift.
 #swift_devices_name: "KOLLA_SWIFT_DATA"
+
+
+########################################################################
+# dashboard_webroot - Access openstack dashboard by dashboard_webroot
+########################################################################
+dashboard_webroot: ""


### PR DESCRIPTION
In our project,i added a feature that  access dashboard page use the dashboard_webroot config.
For example,http://localhost/dashboard/auth/login,the dash_webroot value can be modified in /etc/kolla/globals.yml,then default dashboard_webroot value in all.yml.
So i pull request the feature of dashboard_webroot config 
