### PR TITLE
Fix RPM names for Liberty to build proper base images & configurable multidomain knob

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -219,6 +219,12 @@ kolla_enable_tls_external: "no"
 kolla_external_fqdn_cert: "{{ node_config_directory }}/certificates/haproxy.pem"
 
 
+#####################
+# Horizon options
+#####################
+horizon_multidomain_support: True
+
+
 ####################
 # Kibana options
 ####################

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -65,7 +65,7 @@ OPENSTACK_API_VERSIONS = {
 
 # Set this to True if running on multi-domain model. When this is enabled, it
 # will require user to enter the Domain name in addition to username for login.
-OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = True
+OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = {{ horizon_multidomain_support }}
 
 # Overrides the default domain used when running on single-domain model
 # with Keystone V3. All entities will be created in the default domain.

--- a/docker/openstack-base/Dockerfile.j2
+++ b/docker/openstack-base/Dockerfile.j2
@@ -48,17 +48,17 @@ RUN yum -y install \
         python2-greenlet \
         python2-iso8601 \
         python2-msgpack \
-        python2-oslo-concurrency \
+        python-oslo-concurrency \
         python2-oslo-config \
         python2-oslo-context \
-        python2-oslo-db \
+        python-oslo-db \
         python2-oslo-i18n \
-        python2-oslo-log \
-        python2-oslo-messaging \
-        python2-oslo-middleware \
-        python2-oslo-policy \
+        python-oslo-log \
+        python-oslo-messaging \
+        python-oslo-middleware \
+        python-oslo-policy \
         python2-oslo-serialization \
-        python2-oslo-service \
+        python-oslo-service \
         python2-oslo-utils \
         python2-pika \
         python2-pika_pool \


### PR DESCRIPTION
Hello,

When trying to start OpenStack Liberty containers I would get errors about missing oslo.policy library for some containers. Comparing the package names with ones from a working controller, I found a bunch of discrepancies between the two setups. This patch fixes those RPM names (I guess the packages were renamed for the Mitaka release?).

Another change contained in this PR is making the multidomain support flag configurable, from a hardcoded value of True.

I'm bundling both changes together as these were the main changes I had to do to be able to add a Kolla-deployed controller to an already existing Liberty instance. But please let me know if you'd prefer them as separate PR/patches.

Kind regards.