### PR TITLE
Changed Rabbit preflight - Uses invalid variable

### DIFF
--- a/ansible/roles/prechecks/tasks/port_checks.yml
+++ b/ansible/roles/prechecks/tasks/port_checks.yml
@@ -440,7 +440,7 @@
   when: inventory_hostname in groups['rabbitmq']
 
 - name: Check if all rabbit hostnames are resolvable
-  command: "getent ahostsv4 {{ hostvars[item]['ansible_hostname'] }}"
+  command: "getent ahostsv4 {{ hostvars[item]['inventory_hostname'] }}"
   changed_when: false
   register: rabbitmq_hostnames
   with_items: "{{ groups['rabbitmq'] }}"


### PR DESCRIPTION
Why does this check not use the same variable as the rest

command: "getent ahostsv4 {{ hostvars[item]['ansible_hostname'] }}"
                                                                         ^^^^^^^^^^^^^^^^^^^^^^
Produces this output

FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'ansible_hostname'\n\nThe error appears to have been in '/usr/share/kolla/ansible/roles/prechecks/tasks/port_checks.yml': line 442, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Check if all rabbit hostnames are resolvable\n  ^ here\n"}


A change from variable ansible_hostname to inventory_hostname fixes the issue.