### PR TITLE
Wrong type of interface in mongodb  bootstrap_cluster.js template

### DIFF
--- a/ansible/roles/mongodb/templates/bootstrap_cluster.js.j2
+++ b/ansible/roles/mongodb/templates/bootstrap_cluster.js.j2
@@ -6,7 +6,7 @@ printjson(rs.initiate(
       {% for host in groups["mongodb"] %}
       {
         "_id" : {{ loop.index }},
-        "host" : "{{ hostvars[host]['ansible_' + storage_interface]['ipv4']['address'] }}:{{ mongodb_port }}"
+        "host" : "{{ hostvars[host]['ansible_' +  hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ mongodb_port }}"
       }{% if not loop.last %},{% endif %}
       {% endfor %}
     ]


### PR DESCRIPTION
There is wrong type of interface specified in ansible/roles/mongodb/templates/bootstrap_cluster.js.j2
both in:
 - https://github.com/openstack/kolla-ansible/blob/master/ansible/roles/mongodb/templates/bootstrap_cluster.js.j2
 - https://github.com/openstack/kolla/blob/stable/newton/ansible/roles/mongodb/templates/bootstrap_cluster.js.j2

This wasn't picked earlier probably because of allinone deployments without customizing interfaces. Which basically means = api_interface==storage_interface==network_interface. Most docker containers including mongodb bind to api_interface. This template is used during task "Bootstraping the mongodb replication set" whenever api_interface!=storage_interface it fails because mongodb container doesn't listen on this address.

Fixes https://bugs.launchpad.net/kolla/+bug/1663128