### PR TITLE
Bug on extend_start.sh

### DIFF
--- a/docker/octavia/octavia-api/extend_start.sh
+++ b/docker/octavia/octavia-api/extend_start.sh
@@ -19,4 +19,3 @@ if [[ "$(whoami)" == 'root' ]]; then
         rm -rf /var/run/httpd/* /run/httpd/* /tmp/httpd*
     fi
 fi
-~


### PR DESCRIPTION
Hi, 
my container octavia-api kept restarting without giving me any logs. Internally on the container i saw this error:
line 22: /var/lib/octavia: Is a directory
After i removed the tilde at the end of the file the container started successfully. Could be a bug?