### PR TITLE
Add mips architecture on Loongson platform.

### DIFF
--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -21,7 +21,7 @@ from kolla.version import version_info as version
 
 
 BASE_OS_DISTRO = ['centos', 'rhel', 'ubuntu', 'debian']
-BASE_ARCH = ['x86_64', 'ppc64le', 'aarch64']
+BASE_ARCH = ['x86_64', 'ppc64le', 'aarch64', 'mips64']
 DEFAULT_BASE_TAGS = {
     'centos': '7',
     'rhel': '7',


### PR DESCRIPTION
Runs well on Loongson platform and without affecting the software.