### PR TITLE
Add OSProfiler OTLP exporter dependencies

### DIFF
--- a/docker/openstack-base/Dockerfile.j2
+++ b/docker/openstack-base/Dockerfile.j2
@@ -132,7 +132,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
         'oslo.utils',
         'oslo.versionedobjects',
         'oslo.vmware',
-        'osprofiler',
+        'osprofiler[otlp]',
         'paramiko',
         'pbr',
         'pecan',

--- a/releasenotes/notes/osprofiler-otlp-dependencies-e881203dc1d74b9b.yaml
+++ b/releasenotes/notes/osprofiler-otlp-dependencies-e881203dc1d74b9b.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Installs the OSProfiler OTLP optional dependencies in images derived from
+    ``openstack-base``. This allows OpenStack services to initialize the
+    OSProfiler ``otlp://`` driver when operators configure an OTLP collector
+    endpoint.


### PR DESCRIPTION
OSProfiler supports the `otlp://` backend and its OTLP driver requires `opentelemetry-sdk` and `opentelemetry-exporter-otlp`. Kolla OpenStack service images currently include `osprofiler` but not these optional OTLP dependencies, so configuring:

```ini
[profiler]
connection_string = otlp://<collector>:4318
```

causes driver initialization to fail at runtime.

This change installs the OSProfiler OTLP optional dependencies in OpenStack service images so operators can export OSProfiler traces to an OpenTelemetry Collector without rebuilding images locally.

Note: Kolla uses OpenDev Gerrit for official review and GitHub PRs are not monitored by the project. This PR mirrors the change while Gerrit upload access is being configured.

Tested:
- `tox -e pep8`
- `reno lint`
- `bash tools/validate-all-dockerfiles.sh`
- `uv run --with Jinja2 python tools/validate-all-file.py`